### PR TITLE
Drop deprecated formatter module from globalmodules.zcml

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ CHANGES
 
 - Drop support for Python 3.4.
 
+- Drop security declarations for the deprecated ``formatter`` standard library
+  module from globalmodules.zcml.
+
+  Note that globalmodules.zcml should be avoided.  It's better to make
+  declarations for only what you actually need to use.
+
 
 4.0.0 (2017-04-27)
 ------------------

--- a/src/zope/app/security/globalmodules.zcml
+++ b/src/zope/app/security/globalmodules.zcml
@@ -317,11 +317,6 @@
 
   <!-- 12. Internet Data Handling -->
 
-  <module module="formatter">
-    <allow attributes="AS_IS AbstractFormatter AbstractWriter DumbWriter
-                       NullFormatter NullWriter" />
-  </module>
-
   <module module="email">
     <allow attributes="message_from_file message_from_string" />
   </module>

--- a/src/zope/app/security/globalmodules.zcml
+++ b/src/zope/app/security/globalmodules.zcml
@@ -492,8 +492,8 @@
 
   <!-- The following package has been deprecated in Python 3.4.
        Let's use a similar trick of detecting whether the package
-       "statistics" is available, as it was added in 3.4. -->
-  <module module="formatter" zcml:condition="not-installed statistics">
+       "asyncio" is available, as it was added in 3.4. -->
+  <module module="formatter" zcml:condition="not-installed asyncio">
     <allow attributes="AS_IS AbstractFormatter AbstractWriter DumbWriter
                        NullFormatter NullWriter" />
   </module>

--- a/src/zope/app/security/globalmodules.zcml
+++ b/src/zope/app/security/globalmodules.zcml
@@ -487,7 +487,15 @@
     </module>
     <module module="multifile">
       <allow attributes="MultiFile" />
-    </module>>
+    </module>
   </configure>
+
+  <!-- The following package has been deprecated in Python 3.4.
+       Let's use a similar trick of detecting whether the package
+       "statistics" is available, as it was added in 3.4. -->
+  <module module="formatter" zcml:condition="not-installed statistics">
+    <allow attributes="AS_IS AbstractFormatter AbstractWriter DumbWriter
+                       NullFormatter NullWriter" />
+  </module>
 
 </configure>


### PR DESCRIPTION
Fixes #3.

See also commit 5f31ac1fe1657a19c2142a6df941fbd01fc62b24 that dropped some deprecated modules in 3.7.1, but did that in a clever way that checks Python versions via stdlib module availability.