### PR TITLE
Drop security declarations for binhex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ CHANGES
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Drop security declarations for the deprecated ``binhex`` standard library
+  module from globalmodules.zcml.
+
+  Note that globalmodules.zcml should be avoided.  It's better to make
+  declarations for only what you actually need to use.
 
 
 5.0.0 (2019-07-12)

--- a/src/zope/app/security/globalmodules.zcml
+++ b/src/zope/app/security/globalmodules.zcml
@@ -350,10 +350,6 @@
                        Incomplete" />
   </module>
 
-  <module module="binhex">
-    <allow attributes="binhex hexbin Error" />
-  </module>
-
   <module module="quopri">
     <allow attributes="decode encode decodestring encodestring" />
   </module>


### PR DESCRIPTION
These cause

    .../lib/python3.9/site-packages/zope/configuration/config.py:226: DeprecationWarning: the binhex module is deprecated
      __import__(mname)

on Python 3.9