### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ CHANGES
 8.0 (unreleased)
 ----------------
 
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 - Drop support for Python 3.8.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 CHANGES
 =======
 
-7.1 (unreleased)
+8.0 (unreleased)
 ----------------
 
 - Drop support for Python 3.8.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@
 
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -33,7 +32,7 @@ def read(*rnames):
 
 test_requires = [
     'zope.app.wsgi',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'webtest',
 ]
 
@@ -77,9 +76,6 @@ setup(name='zope.app.security',
       ],
       url='http://github.com/zopefoundation/zope.app.security',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope', 'zope.app'],
       python_requires='>=3.9',
       extras_require={
           'test': test_requires,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '7.1.dev0'
+version = '8.0.dev0'
 
 
 def read(*rnames):

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover

--- a/src/zope/app/__init__.py
+++ b/src/zope/app/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
